### PR TITLE
fix default cacheKey - fixes #3

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = function (fn, opts) {
 	opts = opts || {};
 
 	var cacheKey = opts.cacheKey || function (x) {
-		if (arguments.length === 1 && x === null || x === undefined || (typeof x !== 'function' && typeof x !== 'object')) {
+		if (arguments.length === 1 && (x === null || x === undefined || (typeof x !== 'function' && typeof x !== 'object'))) {
 			return x;
 		}
 

--- a/test.js
+++ b/test.js
@@ -12,6 +12,9 @@ test('memoize', t => {
 	t.is(memoized('foo'), 1);
 	t.is(memoized('foo'), 1);
 	t.is(memoized('foo'), 1);
+	t.is(memoized('foo', 'bar'), 2);
+	t.is(memoized('foo', 'bar'), 2);
+	t.is(memoized('foo', 'bar'), 2);
 });
 
 test('memoize with multiple non-primitive arguments', t => {
@@ -21,6 +24,8 @@ test('memoize with multiple non-primitive arguments', t => {
 	t.is(memoized(), 0);
 	t.is(memoized({foo: true}, {bar: false}), 1);
 	t.is(memoized({foo: true}, {bar: false}), 1);
+	t.is(memoized({foo: true}, {bar: false}, {baz: true}), 2);
+	t.is(memoized({foo: true}, {bar: false}, {baz: true}), 2);
 });
 
 test('maxAge option', async t => {


### PR DESCRIPTION
As described in #3, when the first argument was a primitive, it always took that argument as the only key in the cache because of `typeof x !== 'function' && typeof x !== 'object'`.