### PR TITLE
Add support for clearing cache for specific function arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = (fn, opts) => {
 	}, opts);
 
 	const memoized = function () {
-		const cache = cacheStore.get(memoized);
+		const {cache} = cacheStore.get(memoized);
 		const key = opts.cacheKey.apply(null, arguments);
 
 		if (cache.has(key)) {
@@ -41,13 +41,17 @@ module.exports = (fn, opts) => {
 
 	mimicFn(memoized, fn);
 
-	cacheStore.set(memoized, opts.cache);
+	cacheStore.set(memoized, opts);
 
 	return memoized;
 };
 
-module.exports.clear = fn => {
-	const cache = cacheStore.get(fn);
+module.exports.clear = (fn, key = []) => {
+	const {cache, cacheKey} = cacheStore.get(fn);
+
+	if (Array.isArray(key)) {
+		return cache.delete(cacheKey.apply(null, key));
+	}
 
 	if (cache && typeof cache.clear === 'function') {
 		cache.clear();

--- a/readme.md
+++ b/readme.md
@@ -106,9 +106,9 @@ Default: `new Map()`
 
 Use a different cache storage. Must implement the following methods: `.has(key)`, `.get(key)`, `.set(key, value)`, and optionally `.clear()`. You could for example use a `WeakMap` instead.
 
-### mem.clear(fn)
+### mem.clear(fn, [arguments])
 
-Clear all cached data of a memoized function.
+Without arguments, it clear all cached data of a memoized function
 
 #### fn
 
@@ -116,6 +116,28 @@ Type: `Function`
 
 Memoized function.
 
+#### arguments
+Type: `Array`<br>
+Default: `[]`
+
+You could clear cached data of memoized function only for specific arguments.
+
+```js
+let i = 0;
+const f = () => i++;
+const memoized = mem(f);
+memoized('foo')
+//=> 0
+memoized('bar')
+//=> 1
+
+m.clear(memoized, ['bar']);
+
+memoized('foo')
+//=> 0
+memoized('bar')
+//=> 2
+```
 
 ## Tips
 

--- a/test.js
+++ b/test.js
@@ -88,3 +88,14 @@ test('.clear()', t => {
 	t.is(memoized(), 1);
 	t.is(memoized(), 1);
 });
+
+test('.clear(fn, [key])', t => {
+	let i = 0;
+	const f = () => i++;
+	const memoized = m(f);
+	t.is(memoized('foo'), 0);
+	t.is(memoized('bar'), 1);
+	m.clear(memoized, ['bar']);
+	t.is(memoized('foo'), 0);
+	t.is(memoized('bar'), 2);
+});


### PR DESCRIPTION
Sometime due to bad connection `got` return the rejected promise (timeout), which is not good to be cached. 
It would be nice to be able to clear ONLY that data while the others still remain untouched.