### PR TITLE
Don't cache rejected promises - fixes #8

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = (fn, opts) => {
 	opts = Object.assign({
 		cacheKey: defaultCacheKey,
 		cache: new Map(),
-		cacheRejection: false
+		cachePromiseRejection: false
 	}, opts);
 
 	const memoized = function () {
@@ -33,21 +33,22 @@ module.exports = (fn, opts) => {
 
 		const ret = fn.apply(null, arguments);
 
-		if (isPromise(ret) && opts.cacheRejection === false) {
-			// Only cache resolved promises unless `cacheRejection` is set to `true`
+		const setData = (key, data) => {
+			cache.set(key, {
+				data,
+				maxAge: Date.now() + (opts.maxAge || 0)
+			});
+		};
+
+		if (isPromise(ret) && opts.cachePromiseRejection === false) {
+			// Only cache resolved promises unless `cachePromiseRejection` is set to `true`
 			ret
 				.then(() => {
-					cache.set(key, {
-						data: ret,
-						maxAge: Date.now() + (opts.maxAge || 0)
-					});
+					setData(key, ret);
 				})
 				.catch(() => { });
 		} else {
-			cache.set(key, {
-				data: ret,
-				maxAge: Date.now() + (opts.maxAge || 0)
-			});
+			setData(key, ret);
 		}
 
 		return ret;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const mimicFn = require('mimic-fn');
+const isPromise = require('p-is-promise');
 
 const cacheStore = new WeakMap();
 
@@ -14,7 +15,8 @@ const defaultCacheKey = function (x) {
 module.exports = (fn, opts) => {
 	opts = Object.assign({
 		cacheKey: defaultCacheKey,
-		cache: new Map()
+		cache: new Map(),
+		cacheRejection: false
 	}, opts);
 
 	const memoized = function () {
@@ -31,10 +33,22 @@ module.exports = (fn, opts) => {
 
 		const ret = fn.apply(null, arguments);
 
-		cache.set(key, {
-			data: ret,
-			maxAge: Date.now() + (opts.maxAge || 0)
-		});
+		if (isPromise(ret) && opts.cacheRejection === false) {
+			// Only cache resolved promises unless `cacheRejection` is set to `true`
+			ret
+				.then(() => {
+					cache.set(key, {
+						data: ret,
+						maxAge: Date.now() + (opts.maxAge || 0)
+					});
+				})
+				.catch(() => { });
+		} else {
+			cache.set(key, {
+				data: ret,
+				maxAge: Date.now() + (opts.maxAge || 0)
+			});
+		}
 
 		return ret;
 	};

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "promise"
   ],
   "dependencies": {
-    "mimic-fn": "^1.0.0"
+    "mimic-fn": "^1.0.0",
+    "p-is-promise": "^1.1.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,13 @@ Default: `new Map()`
 
 Use a different cache storage. Must implement the following methods: `.has(key)`, `.get(key)`, `.set(key, value)`, and optionally `.clear()`. You could for example use a `WeakMap` instead or [`quick-lru`](https://github.com/sindresorhus/quick-lru) for a LRU cache.
 
+##### cacheRejection
+
+Type: `boolean`<br>
+Default: `false`
+
+Set to `true` if you want to cache rejected promises.
+
 ### mem.clear(fn)
 
 Clear all cached data of a memoized function.

--- a/readme.md
+++ b/readme.md
@@ -106,12 +106,12 @@ Default: `new Map()`
 
 Use a different cache storage. Must implement the following methods: `.has(key)`, `.get(key)`, `.set(key, value)`, and optionally `.clear()`. You could for example use a `WeakMap` instead or [`quick-lru`](https://github.com/sindresorhus/quick-lru) for a LRU cache.
 
-##### cacheRejection
+##### cachePromiseRejection
 
 Type: `boolean`<br>
 Default: `false`
 
-Set to `true` if you want to cache rejected promises.
+Cache rejected promises.
 
 ### mem.clear(fn)
 

--- a/test.js
+++ b/test.js
@@ -76,13 +76,13 @@ test('promise support', async t => {
 
 test('do not cache rejected promises', async t => {
 	let i = 0;
-	const memoized = m(() => {
+	const memoized = m(async () => {
 		i++;
 		if (i === 1) {
-			return Promise.reject(new Error('foo bar'));
+			throw new Error('foo bar');
 		}
 
-		return Promise.resolve(i);
+		return i;
 	});
 
 	await t.throws(memoized(), 'foo bar');

--- a/test.js
+++ b/test.js
@@ -92,15 +92,16 @@ test('do not cache rejected promises', async t => {
 
 test('cache rejected promises if enabled', async t => {
 	let i = 0;
-	const memoized = m(() => {
+	const memoized = m(async () => {
 		i++;
+
 		if (i === 1) {
-			return Promise.reject(new Error('foo bar'));
+			throw new Error('foo bar');
 		}
 
-		return Promise.resolve(i);
+		return i;
 	}, {
-		cacheRejection: true
+		cachePromiseRejection: true
 	});
 
 	await t.throws(memoized(), 'foo bar');

--- a/test.js
+++ b/test.js
@@ -74,6 +74,40 @@ test('promise support', async t => {
 	t.is(await memoized(10), 1);
 });
 
+test('do not cache rejected promises', async t => {
+	let i = 0;
+	const memoized = m(() => {
+		i++;
+		if (i === 1) {
+			return Promise.reject(new Error('foo bar'));
+		}
+
+		return Promise.resolve(i);
+	});
+
+	await t.throws(memoized(), 'foo bar');
+	t.is(await memoized(), 2);
+	t.is(await memoized(), 2);
+});
+
+test('cache rejected promises if enabled', async t => {
+	let i = 0;
+	const memoized = m(() => {
+		i++;
+		if (i === 1) {
+			return Promise.reject(new Error('foo bar'));
+		}
+
+		return Promise.resolve(i);
+	}, {
+		cacheRejection: true
+	});
+
+	await t.throws(memoized(), 'foo bar');
+	await t.throws(memoized(), 'foo bar');
+	await t.throws(memoized(), 'foo bar');
+});
+
 test('preserves the original function name', t => {
 	t.is(m(function foo() {}).name, 'foo'); // eslint-disable-line func-names, prefer-arrow-callback
 });


### PR DESCRIPTION
This PR fixes #8 by not caching a rejected promise by default. I also added a `cacheRejection` option (couldn't come up with a better name) to re-enable it.

Feedback welcome!