### PR TITLE
Delete cache entries older than max age

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,8 @@ module.exports = (fn, opts) => {
 			if (typeof opts.maxAge !== 'number' || Date.now() < c.maxAge) {
 				return c.data;
 			}
+
+			cache.delete(key);
 		}
 
 		const ret = fn.apply(this, arguments);

--- a/test.js
+++ b/test.js
@@ -40,6 +40,25 @@ test('maxAge option', async t => {
 	t.is(memoized(1), 1);
 });
 
+test('maxAge option deletes old items', async t => {
+	let i = 0;
+	const f = () => i++;
+	const cache = new Map();
+	const deleted = [];
+	cache.delete = item => deleted.push(item);
+	const memoized = m(f, {maxAge: 100, cache});
+	t.is(memoized(1), 0);
+	t.is(memoized(1), 0);
+	t.is(cache.has(1), true);
+	await delay(50);
+	t.is(memoized(1), 0);
+	t.is(deleted.length, 0);
+	await delay(200);
+	t.is(memoized(1), 1);
+	t.is(deleted.length, 1);
+	t.is(deleted[0], 1);
+});
+
 test('cacheKey option', t => {
 	let i = 0;
 	const f = () => i++;

--- a/test.js
+++ b/test.js
@@ -59,6 +59,26 @@ test('maxAge option deletes old items', async t => {
 	t.is(deleted[0], 1);
 });
 
+test('maxAge items are deleted even if function throws', async t => {
+	let i = 0;
+	const f = () => {
+		if (i === 1) {
+			throw new Error('failure');
+		}
+		return i++;
+	};
+	const cache = new Map();
+	const memoized = m(f, {maxAge: 100, cache});
+	t.is(memoized(1), 0);
+	t.is(memoized(1), 0);
+	t.is(cache.size, 1);
+	await delay(50);
+	t.is(memoized(1), 0);
+	await delay(200);
+	t.throws(() => memoized(1), 'failure');
+	t.is(cache.size, 0);
+});
+
 test('cacheKey option', t => {
 	let i = 0;
 	const f = () => i++;


### PR DESCRIPTION
Related to #14 although it might not fix it explicitly. 

This explicitly calls `delete()` if the max age has passed, so that if passing a caching object that is maybe different to `Map` then it doesn't rely on `set()` in order to actually remove old entries.

This also fixes a bug where if a subsequent call to `fn` may throw an error (even if the original call did not - perhaps because some side-effect has changed, e.g. a filesystem - causing `fn` to now throw) - then the `.set` was never called and so older entries would remain without ever being explicitly cleared up.