### PR TITLE
Performance enhancements

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,8 @@ module.exports = (fn, options) => {
 	}, options);
 
 	const {cache} = options;
+	const noMaxAge = typeof options.maxAge !== 'number';
+	options.maxAge = options.maxAge || 0;
 
 	const setData = (key, data) => {
 		cache.set(key, {
@@ -44,7 +46,7 @@ module.exports = (fn, options) => {
 		if (cache.has(key)) {
 			const c = cache.get(key);
 
-			if (typeof options.maxAge !== 'number' || Date.now() < c.maxAge) {
+			if (noMaxAge || Date.now() < c.maxAge) {
 				return c.data;
 			}
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const defaultCacheKey = (...args) => {
 	if (args.length === 0) {
 		return '__defaultKey';
 	}
+
 	if (args.length === 1) {
 		const [firstArgument] = args;
 		if (

--- a/index.js
+++ b/index.js
@@ -29,8 +29,16 @@ module.exports = (fn, options) => {
 		cachePromiseRejection: false
 	}, options);
 
+	const {cache} = options;
+
+	const setData = (key, data) => {
+		cache.set(key, {
+			data,
+			maxAge: Date.now() + options.maxAge
+		});
+	};
+
 	const memoized = function (...args) {
-		const cache = cacheStore.get(memoized);
 		const key = options.cacheKey(...args);
 
 		if (cache.has(key)) {
@@ -44,13 +52,6 @@ module.exports = (fn, options) => {
 		}
 
 		const ret = fn.call(this, ...args);
-
-		const setData = (key, data) => {
-			cache.set(key, {
-				data,
-				maxAge: Date.now() + (options.maxAge || 0)
-			});
-		};
 
 		setData(key, ret);
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ const isPromise = require('p-is-promise');
 const cacheStore = new WeakMap();
 
 const defaultCacheKey = (...args) => {
+	if (args.length === 0) {
+		return '__defaultKey';
+	}
 	if (args.length === 1) {
 		const [firstArgument] = args;
 		if (


### PR DESCRIPTION
A few minor performance enhancements

- Don't look in the `cacheStore` on every function call, keep in local variable
- Don't recreate `setData` function on every function call
- Set a default key for when `args` is empty instead of calling JSON.stringify
- Calculate some parameters for `maxAge` logic ahead of time

Results:
`8.3x` speedup for empty arguments
`1.86x` speedup for single arguments
`1.1x` speedup for complex arguments

Benchmark Code:
```
const mp = require('./perf');
const m = require('./index');

const argSets = [
  [],
  [0],
  ['foo', 'bar', 'baz'],
  [{foo: true}, {bar: false}]
];

const scenarios = [
  {
    mem: mp,
    name: 'Perf    ',
  },
  {
    mem: m,
    name: 'Original'
  }
];

const N = 1e8;

for (let args of argSets) {
  for (let {mem, name} of scenarios) {
    let i = 0;
    const f = () => i++;
    const memoized = mem(f);
    const title = `${name} - with args: ${JSON.stringify(args)}`;

    console.time(title);
    for (let i = 0; i < N; i++) {
      memoized.call(memoized, ...args)
    }
    console.timeEnd(title);
  }
}
```

Results:
```
Perf     - with args: []: 3929.611ms
Original - with args: []: 32624.623ms
Perf     - with args: [0]: 5355.543ms
Original - with args: [0]: 9960.462ms
Perf     - with args: ["foo","bar","baz"]: 44711.881ms
Original - with args: ["foo","bar","baz"]: 49462.724ms
Perf     - with args: [{"foo":true},{"bar":false}]: 66376.395ms
Original - with args: [{"foo":true},{"bar":false}]: 75006.349ms
```