### PR TITLE
Add failing tests for RegExp and Symbol arguments

### DIFF
--- a/test.js
+++ b/test.js
@@ -39,6 +39,23 @@ test('memoize with regexp arguments', t => {
 	t.is(memoized(/Elvin Peng/), 2);
 });
 
+test('memoize with Symbol arguments', t => {
+	let i = 0;
+	const arg1 = Symbol('Sindre Sorhus');
+	const arg2 = Symbol('Elvin Peng');
+	const memoized = m(() => i++);
+	t.is(memoized(), 0);
+	t.is(memoized(), 0);
+	t.is(memoized(arg1), 1);
+	t.is(memoized(arg1), 1);
+	t.is(memoized(arg2), 2);
+	t.is(memoized(arg2), 2);
+	t.is(memoized({foo: arg1}), 3);
+	t.is(memoized({foo: arg1}), 3);
+	t.is(memoized({foo: arg2}), 4);
+	t.is(memoized({foo: arg2}), 4);
+});
+
 test('maxAge option', async t => {
 	let i = 0;
 	const f = () => i++;

--- a/test.js
+++ b/test.js
@@ -28,7 +28,7 @@ test('memoize with multiple non-primitive arguments', t => {
 	t.is(memoized({foo: true}, {bar: false}, {baz: true}), 2);
 });
 
-test('memoize with regexp arguments', t => {
+test.failing('memoize with regexp arguments', t => {
 	let i = 0;
 	const memoized = m(() => i++);
 	t.is(memoized(), 0);
@@ -39,10 +39,10 @@ test('memoize with regexp arguments', t => {
 	t.is(memoized(/Elvin Peng/), 2);
 });
 
-test('memoize with Symbol arguments', t => {
+test.failing('memoize with Symbol arguments', t => {
 	let i = 0;
-	const arg1 = Symbol('Sindre Sorhus');
-	const arg2 = Symbol('Elvin Peng');
+	const arg1 = Symbol('fixture1');
+	const arg2 = Symbol('fixture2');
 	const memoized = m(() => i++);
 	t.is(memoized(), 0);
 	t.is(memoized(), 0);

--- a/test.js
+++ b/test.js
@@ -28,6 +28,17 @@ test('memoize with multiple non-primitive arguments', t => {
 	t.is(memoized({foo: true}, {bar: false}, {baz: true}), 2);
 });
 
+test('memoize with regexp arguments', t => {
+	let i = 0;
+	const memoized = m(() => i++);
+	t.is(memoized(), 0);
+	t.is(memoized(), 0);
+	t.is(memoized(/Sindre Sorhus/), 1);
+	t.is(memoized(/Sindre Sorhus/), 1);
+	t.is(memoized(/Elvin Peng/), 2);
+	t.is(memoized(/Elvin Peng/), 2);
+});
+
 test('maxAge option', async t => {
 	let i = 0;
 	const f = () => i++;


### PR DESCRIPTION
Add tests for #20.

CI tests will fail in `memoize with regexp arguments` and `memoize with Symbol arguments`.