### PR TITLE
Better support for Symbol, null, undefined, Infinity, NaN

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
 	"dependencies": {
 		"map-age-cleaner": "^0.1.1",
 		"mimic-fn": "^1.0.0",
-		"p-is-promise": "^1.1.0"
+		"p-is-promise": "^1.1.0",
+		"uuid": "^3.3.2"
 	},
 	"devDependencies": {
 		"ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,58 @@ memoized('bar');
 //=> 2
 ```
 
+## Objects and Custom Types
+
+```javascript
+const mem = require('mem');
+
+let i = 0;
+const memoized = mem(() => ++i);
+
+// mem uses JSON.stringify internally to generate cache keys. Objects with the 
+// same property values are treated identically
+memoized({a: 1});
+//=> 1
+
+memoized({a: 1});
+//=> 1
+
+// Note - this may lead to unexpected behavior with certain types of objects
+// For example Regex builtins 
+JSON.stringify(/[A-Z]+/);
+//=> '{}'
+
+memoized(/[A-Z]+/);
+//=> 2
+
+// Additional Regexes also serialize to '{}', and will not function as expected 
+memoized(/^memo$/);
+//=> 2
+
+// If you use types that don't play well with JSON.stringify, define your own cacheKey
+const cacheKey = (regex, string) => regex.toString() + string;
+let j = 0;
+const memRegex = mem(() => ++j, {cacheKey}); 
+
+memRegex(/[A-Z]+/, 'string');
+//=> 0
+
+memRegex(/[A-Z]+/, 'string');
+//=> 0
+
+memRegex(/[A-Z]+/, 'different');
+//=> 1
+
+memRegex(/[A-Z]+/, 'different');
+//=> 1
+
+memRegex(/^memo$/, 'string');
+//=> 2
+
+memRegex(/^memo$/, 'string');
+//=> 2
+```
+
 ##### Works fine with promise returning functions
 
 ```js

--- a/test.js
+++ b/test.js
@@ -39,6 +39,23 @@ test('memoize with regexp arguments', t => {
 	t.is(memoized(/Elvin Peng/), 2);
 });
 
+test('memoize with Symbol arguments', t => {
+	let i = 0;
+	const arg1 = Symbol('Sindre Sorhus');
+	const arg2 = Symbol('Elvin Peng');
+	const memoized = m(() => i++);
+	t.is(memoized(), 0);
+	t.is(memoized(), 0);
+	t.is(memoized(arg1), 1);
+	t.is(memoized(arg1), 1);
+	t.is(memoized(arg2), 2);
+	t.is(memoized(arg2), 2);
+	t.is(memoized({foo: arg1}), 3);
+	t.is(memoized({foo: arg1}), 3);
+	t.is(memoized({foo: arg2}), 4);
+	t.is(memoized({foo: arg2}), 4);
+});
+
 test('maxAge option', async t => {
 	let i = 0;
 	const f = () => i++;

--- a/test.js
+++ b/test.js
@@ -28,6 +28,17 @@ test('memoize with multiple non-primitive arguments', t => {
 	t.is(memoized({foo: true}, {bar: false}, {baz: true}), 2);
 });
 
+test('memoize with regexp arguments', t => {
+	let i = 0;
+	const memoized = m(() => i++);
+	t.is(memoized(), 0);
+	t.is(memoized(), 0);
+	t.is(memoized(/Sindre Sorhus/), 1);
+	t.is(memoized(/Sindre Sorhus/), 1);
+	t.is(memoized(/Elvin Peng/), 2);
+	t.is(memoized(/Elvin Peng/), 2);
+});
+
 test('maxAge option', async t => {
 	let i = 0;
 	const f = () => i++;

--- a/test.js
+++ b/test.js
@@ -1,3 +1,6 @@
+'use strict';
+/* eslint-disable require-await */
+
 import test from 'ava';
 import delay from 'delay';
 import m from '.';
@@ -28,15 +31,58 @@ test('memoize with multiple non-primitive arguments', t => {
 	t.is(memoized({foo: true}, {bar: false}, {baz: true}), 2);
 });
 
-test('memoize with regexp arguments', t => {
+test('memoize with null and undefined', t => {
 	let i = 0;
 	const memoized = m(() => i++);
 	t.is(memoized(), 0);
 	t.is(memoized(), 0);
-	t.is(memoized(/Sindre Sorhus/), 1);
-	t.is(memoized(/Sindre Sorhus/), 1);
-	t.is(memoized(/Elvin Peng/), 2);
-	t.is(memoized(/Elvin Peng/), 2);
+	t.is(memoized(null), 1);
+	t.is(memoized(null), 1);
+	t.is(memoized(undefined), 2);
+	t.is(memoized(undefined), 2);
+	t.is(memoized([null, undefined]), 3);
+	t.is(memoized([null, undefined]), 3);
+	t.is(memoized([undefined, null]), 4);
+	t.is(memoized([undefined, null]), 4);
+	t.is(memoized('undefined'), 5);
+	t.is(memoized('undefined'), 5);
+	t.is(memoized('null'), 6);
+	t.is(memoized('null'), 6);
+	t.is(memoized(null, null), 7);
+	t.is(memoized(null, null), 7);
+	t.is(memoized('null', 'null'), 8);
+	t.is(memoized('null', 'null'), 8);
+	t.is(memoized(undefined, undefined), 9);
+	t.is(memoized(undefined, undefined), 9);
+	t.is(memoized('undefined', 'undefined'), 10);
+	t.is(memoized('undefined', 'undefined'), 10);
+});
+
+test('memoize with Inifinity and NaN', t => {
+	let i = 0;
+	const memoized = m(() => i++);
+	t.is(memoized(), 0);
+	t.is(memoized(), 0);
+	t.is(memoized(Infinity), 1);
+	t.is(memoized(Infinity), 1);
+	t.is(memoized(NaN), 2);
+	t.is(memoized(NaN), 2);
+	t.is(memoized([Infinity, NaN]), 3);
+	t.is(memoized([Infinity, NaN]), 3);
+	t.is(memoized([NaN, Infinity]), 4);
+	t.is(memoized([NaN, Infinity]), 4);
+	t.is(memoized('NaN'), 5);
+	t.is(memoized('NaN'), 5);
+	t.is(memoized('Infinity'), 6);
+	t.is(memoized('Infinity'), 6);
+	t.is(memoized(Infinity, Infinity), 7);
+	t.is(memoized(Infinity, Infinity), 7);
+	t.is(memoized('Infinity', 'Infinity'), 8);
+	t.is(memoized('Infinity', 'Infinity'), 8);
+	t.is(memoized(NaN, NaN), 9);
+	t.is(memoized(NaN, NaN), 9);
+	t.is(memoized('NaN', 'NaN'), 10);
+	t.is(memoized('NaN', 'NaN'), 10);
 });
 
 test('memoize with Symbol arguments', t => {
@@ -54,6 +100,37 @@ test('memoize with Symbol arguments', t => {
 	t.is(memoized({foo: arg1}), 3);
 	t.is(memoized({foo: arg2}), 4);
 	t.is(memoized({foo: arg2}), 4);
+});
+
+test('memoize with custom types', t => {
+	function Programmer(name, cupsOfCoffee) {
+		this.name = name;
+		this.cupsOfCoffee = cupsOfCoffee;
+	}
+	Programmer.prototype.drinkCup = function () {
+		this.cupsOfCoffee += 1;
+	};
+	const joe = new Programmer('joe', 3);
+	const joe2 = new Programmer('joe', 3);
+	const bean = new Programmer('bean', 2);
+	let i = 0;
+	const memoized = m(() => i++);
+	t.is(memoized(), 0);
+	t.is(memoized(joe), 1);
+	t.is(memoized(joe), 1);
+
+	// Initially joe and joe2 are equal
+	t.is(memoized(joe2), 1);
+	joe2.drinkCup();
+	// After joe2's props change they are not
+	t.is(memoized(joe2), 2);
+
+	t.is(memoized(bean), 3);
+	t.is(memoized(bean), 3);
+	t.is(memoized([joe, joe2, bean]), 4);
+	t.is(memoized([joe, joe2, bean]), 4);
+	t.is(memoized([bean, joe, joe2]), 5);
+	t.is(memoized([bean, joe, joe2]), 5);
 });
 
 test('maxAge option', async t => {
@@ -120,6 +197,19 @@ test('cacheKey option', t => {
 	t.is(memoized(1, 2), 0);
 	t.is(memoized(2), 1);
 	t.is(memoized(2, 1), 1);
+});
+
+test('cacheKey with Regex', t => {
+	let i = 0;
+	const f = () => i++;
+	const cacheKey = (regex, string) => regex.toString() + string;
+	const memoized = m(f, {cacheKey});
+	t.is(memoized(/[A-Z]/, 'string'), 0);
+	t.is(memoized(/[A-Z]/, 'string'), 0);
+	t.is(memoized(/[A-Z]/, 'different'), 1);
+	t.is(memoized(/[A-Z]/, 'different'), 1);
+	t.is(memoized(/^memo$/, 'string'), 2);
+	t.is(memoized(/^memo$/, 'string'), 2);
 });
 
 test('cache option', t => {


### PR DESCRIPTION
Improves the `defaultCacheKey` function to handle types that don't play well with `JSON.stringify` using the approach discussed in https://github.com/sindresorhus/mem/issues/20

Problems I ran into - 
It's impossible to set a symbol as a key in a `WeakMap`, so I had to use a Map instead

```
m = new WeakMap();
m.set(Symbol())
// Uncaught TypeError: Invalid value used as weak map key
```
I don't foresee garbage collection being an issue for two reasons
1. In my experience people generally don't create symbols dynamically, instead they're used as enums at program start
1. Based on [this SO Post](https://stackoverflow.com/questions/39997034/are-es6-global-symbols-garbage-collected) it looks like symbols may not be garbage collected anyway

closes #20 