### PR TITLE
Avoid `Date.now()` call when `maxAge` is not enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = (fn, options) => {
 		cachePromiseRejection: false
 	}, options);
 
-	if (typeof options.maxAge === 'number') {
+	if (typeof options.maxAge === 'number' && options.maxAge > 0) {
 		mapAgeCleaner(options.cache);
 	}
 
@@ -39,9 +39,10 @@ module.exports = (fn, options) => {
 	options.maxAge = options.maxAge || 0;
 
 	const setData = (key, data) => {
+		const maxAge = (options.maxAge > 0) ? Date.now() + options.maxAge : 0;
 		cache.set(key, {
 			data,
-			maxAge: Date.now() + options.maxAge
+			maxAge
 		});
 	};
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,11 @@ module.exports = (fn, options) => {
 		cachePromiseRejection: false
 	}, options);
 
-	if (typeof options.maxAge === 'number' && options.maxAge > 0) {
+	const cacheEvictionEnabled = typeof options.maxAge === 'number';
+	if (cacheEvictionEnabled) {
+		if (options.maxAge < 0 || !isFinite(options.maxAge)) {
+			throw new Error('Option maxAge must be greater than or equal than zero');
+		}
 		mapAgeCleaner(options.cache);
 	}
 
@@ -39,7 +43,7 @@ module.exports = (fn, options) => {
 	options.maxAge = options.maxAge || 0;
 
 	const setData = (key, data) => {
-		const maxAge = (options.maxAge > 0) ? Date.now() + options.maxAge : 0;
+		const maxAge = cacheEvictionEnabled ? Date.now() + options.maxAge : 0;
 		cache.set(key, {
 			data,
 			maxAge

--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ Type: `Object`
 Type: `number`<br>
 Default: `Infinity`
 
-Milliseconds until the cache expires.
+Milliseconds until the cache expires. If value is zero, the cache item will be evicted in the next cleanup stage. If value is negative, `mem` will throw an exception.
 
 ##### cacheKey
 

--- a/test.js
+++ b/test.js
@@ -111,6 +111,18 @@ test('maxAge items are deleted even if function throws', async t => {
 	t.is(cache.size, 0);
 });
 
+test('maxAge:negative throws exception', t => {
+	let i = 0;
+	const f = () => i++;
+	t.throws(() => mem(f, {maxAge: -1}), 'Option maxAge must be greater than or equal than zero');
+});
+
+test('maxAge:nan throws exception', t => {
+	let i = 0;
+	const f = () => i++;
+	t.throws(() => mem(f, {maxAge: Number.NaN}), 'Option maxAge must be greater than or equal than zero');
+});
+
 test('cacheKey option', t => {
 	let i = 0;
 	const f = () => i++;


### PR DESCRIPTION
Avoids relatively expensive Date.now call when maxAge is not enabled. Only enable mapAgeCleaner when options.maxAge is a positive non-zero number.