### PR TITLE
TypeScript - Fix the cache type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,7 +33,7 @@ export interface Options<
 	 *
 	 * @default new Map()
 	 */
-	readonly cache?: CacheStorage<CacheKeyType, { data: ReturnType; maxAge?: number; }>;
+	readonly cache?: CacheStorage<CacheKeyType, { data: ReturnType; maxAge: number; }>;
 
 	/**
 	 * Cache rejected promises.

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,7 +33,7 @@ export interface Options<
 	 *
 	 * @default new Map()
 	 */
-	readonly cache?: CacheStorage<CacheKeyType, ReturnType>;
+	readonly cache?: CacheStorage<CacheKeyType, { data: ReturnType; maxAge?: number; }>;
 
 	/**
 	 * Cache rejected promises.

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,7 +33,7 @@ export interface Options<
 	 *
 	 * @default new Map()
 	 */
-	readonly cache?: CacheStorage<CacheKeyType, { data: ReturnType; maxAge: number; }>;
+	readonly cache?: CacheStorage<CacheKeyType, {data: ReturnType; maxAge: number}>;
 
 	/**
 	 * Cache rejected promises.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,10 +7,10 @@ expectType<(string: string) => boolean>(mem(fn));
 expectType<(string: string) => boolean>(mem(fn, {maxAge: 1}));
 expectType<(string: string) => boolean>(mem(fn, {cacheKey: (...arguments_) => arguments_}));
 expectType<(string: string) => boolean>(
-	mem(fn, {cacheKey: (...arguments_) => arguments_, cache: new Map<[string], boolean>()})
+	mem(fn, {cacheKey: (...arguments_) => arguments_, cache: new Map<[string], { data: boolean }>()})
 );
 expectType<(string: string) => boolean>(
-	mem(fn, {cache: new Map<[string], boolean>()})
+	mem(fn, {cache: new Map<[string], { data: boolean; maxAge?: number }>()})
 );
 expectType<(string: string) => boolean>(mem(fn, {cachePromiseRejection: true}));
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -10,10 +10,10 @@ expectType<(string: string) => boolean>(
 	mem(
 		fn,
 		{cacheKey: (...arguments_) => arguments_,
-		cache: new Map<[string], { data: boolean; maxAge: number; }>()})
+		cache: new Map<[string], {data: boolean; maxAge: number}>()})
 );
 expectType<(string: string) => boolean>(
-	mem(fn, {cache: new Map<[string], { data: boolean; maxAge: number }>()})
+	mem(fn, {cache: new Map<[string], {data: boolean; maxAge: number}>()})
 );
 expectType<(string: string) => boolean>(mem(fn, {cachePromiseRejection: true}));
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,10 +7,13 @@ expectType<(string: string) => boolean>(mem(fn));
 expectType<(string: string) => boolean>(mem(fn, {maxAge: 1}));
 expectType<(string: string) => boolean>(mem(fn, {cacheKey: (...arguments_) => arguments_}));
 expectType<(string: string) => boolean>(
-	mem(fn, {cacheKey: (...arguments_) => arguments_, cache: new Map<[string], { data: boolean }>()})
+	mem(
+		fn,
+		{cacheKey: (...arguments_) => arguments_,
+		cache: new Map<[string], { data: boolean; maxAge: number; }>()})
 );
 expectType<(string: string) => boolean>(
-	mem(fn, {cache: new Map<[string], { data: boolean; maxAge?: number }>()})
+	mem(fn, {cache: new Map<[string], { data: boolean; maxAge: number }>()})
 );
 expectType<(string: string) => boolean>(mem(fn, {cachePromiseRejection: true}));
 


### PR DESCRIPTION
@sindresorhus Thanks for adding types to your repos! 

I believe the `cache` type needs to include the `data`, otherwise this isn't possible:

```typescript

const cache = new QuickLRU<string, { data: Bundle }>({
    maxSize: BUNDLE_COUNT_TO_MEMORIZE
});

const loadJsonFileMemorized = mem(
    (filename: string) => loadJsonFile<Bundle>(filename),
    {
        cache
    }
);

// After modifying we want to update the cache directly to avoid another load.
cache.set(filename, { data: updatedBundle });
```