### PR TITLE
`mem` is supposed to be callable when `require`'d, in addition to being a `default`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,46 +1,48 @@
-export interface CacheStorage<
-	KeyType extends unknown,
-	ValueType extends unknown
-> {
-	has(key: KeyType): boolean;
-	get(key: KeyType): ValueType | undefined;
-	set(key: KeyType, value: ValueType): void;
-	delete(key: KeyType): void;
-	clear?: () => void;
-}
+declare namespace mem {
+	export interface CacheStorage<
+		KeyType extends unknown,
+		ValueType extends unknown
+	> {
+		has(key: KeyType): boolean;
+		get(key: KeyType): ValueType | undefined;
+		set(key: KeyType, value: ValueType): void;
+		delete(key: KeyType): void;
+		clear?: () => void;
+	}
 
-export interface Options<
-	ArgumentsType extends unknown[],
-	CacheKeyType extends unknown,
-	ReturnType extends unknown
-> {
-	/**
-	 * Milliseconds until the cache expires.
-	 *
-	 * @default Infinity
-	 */
-	readonly maxAge?: number;
+	export interface Options<
+		ArgumentsType extends unknown[],
+		CacheKeyType extends unknown,
+		ReturnType extends unknown
+	> {
+		/**
+		 * Milliseconds until the cache expires.
+		 *
+		 * @default Infinity
+		 */
+		readonly maxAge?: number;
 
-	/**
-	 * Determines the cache key for storing the result based on the function arguments. By default, if there's only one argument and it's a [primitive](https://developer.mozilla.org/en-US/docs/Glossary/Primitive), it's used directly as a key, otherwise it's all the function arguments JSON stringified as an array.
-	 *
-	 * You could for example change it to only cache on the first argument `x => JSON.stringify(x)`.
-	 */
-	readonly cacheKey?: (...arguments: ArgumentsType) => CacheKeyType;
+		/**
+		 * Determines the cache key for storing the result based on the function arguments. By default, if there's only one argument and it's a [primitive](https://developer.mozilla.org/en-US/docs/Glossary/Primitive), it's used directly as a key, otherwise it's all the function arguments JSON stringified as an array.
+		 *
+		 * You could for example change it to only cache on the first argument `x => JSON.stringify(x)`.
+		 */
+		readonly cacheKey?: (...arguments: ArgumentsType) => CacheKeyType;
 
-	/**
-	 * Use a different cache storage. Must implement the following methods: `.has(key)`, `.get(key)`, `.set(key, value)`, `.delete(key)`, and optionally `.clear()`. You could for example use a `WeakMap` instead or [`quick-lru`](https://github.com/sindresorhus/quick-lru) for a LRU cache.
-	 *
-	 * @default new Map()
-	 */
-	readonly cache?: CacheStorage<CacheKeyType, ReturnType>;
+		/**
+		 * Use a different cache storage. Must implement the following methods: `.has(key)`, `.get(key)`, `.set(key, value)`, `.delete(key)`, and optionally `.clear()`. You could for example use a `WeakMap` instead or [`quick-lru`](https://github.com/sindresorhus/quick-lru) for a LRU cache.
+		 *
+		 * @default new Map()
+		 */
+		readonly cache?: CacheStorage<CacheKeyType, ReturnType>;
 
-	/**
-	 * Cache rejected promises.
-	 *
-	 * @default false
-	 */
-	readonly cachePromiseRejection?: boolean;
+		/**
+		 * Cache rejected promises.
+		 *
+		 * @default false
+		 */
+		readonly cachePromiseRejection?: boolean;
+	}
 }
 
 /**
@@ -55,7 +57,7 @@ declare const mem: {
 		CacheKeyType extends unknown
 	>(
 		fn: (...arguments: ArgumentsType) => ReturnType,
-		options?: Options<ArgumentsType, CacheKeyType, ReturnType>
+		options?: mem.Options<ArgumentsType, CacheKeyType, ReturnType>
 	): (...arguments: ArgumentsType) => ReturnType;
 
 	/**
@@ -66,6 +68,7 @@ declare const mem: {
 	clear<ArgumentsType extends unknown[], ReturnType extends unknown>(
 		fn: (...arguments: ArgumentsType) => ReturnType
 	): void;
+	"default": typeof mem;
 };
 
-export default mem;
+export = mem;


### PR DESCRIPTION
Without this the definition file breaks JS intellisense in projects like `prettier`.

@sindresorhus do you have any other cjs packages that do both an `module.exports` assignment and a default member? They should all have definitions that work similarly to this.