### PR TITLE
WIP: Use `ManyKeysMap` for cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,32 +2,13 @@
 const mimicFn = require('mimic-fn');
 const isPromise = require('p-is-promise');
 const mapAgeCleaner = require('map-age-cleaner');
+const ManyKeysMap = require('many-keys-map');
 
 const cacheStore = new WeakMap();
 
-const defaultCacheKey = (...arguments_) => {
-	if (arguments_.length === 0) {
-		return '__defaultKey';
-	}
-
-	if (arguments_.length === 1) {
-		const [firstArgument] = arguments_;
-		if (
-			firstArgument === null ||
-			firstArgument === undefined ||
-			(typeof firstArgument !== 'function' && typeof firstArgument !== 'object')
-		) {
-			return firstArgument;
-		}
-	}
-
-	return JSON.stringify(arguments_);
-};
-
 const mem = (fn, options) => {
 	options = Object.assign({
-		cacheKey: defaultCacheKey,
-		cache: new Map(),
+		cache: new ManyKeysMap(),
 		cachePromiseRejection: false
 	}, options);
 
@@ -45,14 +26,12 @@ const mem = (fn, options) => {
 		});
 	};
 
-	const memoized = function (...arguments_) {
-		const key = options.cacheKey(...arguments_);
-
+	const memoized = function (...key) {
 		if (cache.has(key)) {
 			return cache.get(key).data;
 		}
 
-		const cacheItem = fn.call(this, ...arguments_);
+		const cacheItem = fn.apply(this, key);
 
 		setData(key, cacheItem);
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"promise"
 	],
 	"dependencies": {
+		"many-keys-map": "^1.0.1",
 		"map-age-cleaner": "^0.1.1",
 		"mimic-fn": "^2.0.0",
 		"p-is-promise": "^2.0.0"


### PR DESCRIPTION
Would fix #20
Would replace #22 

The [many-keys-map](https://github.com/bfred-it/many-keys-map) module does exactly what you're trying to do here, however there are two issues:

1. Currently parameters are stored by value, i.e. `{a:1}` and `{a:1}` are treated identically even if they’re not the same object.

	`many-keys-map` doesn’t do that. Objects are cached by reference. This _could_ be solved by continuing to stringify plain objects/arrays (but it could lead to inconsistencies like _"why is `{a:1}` cached by value while `{a:regex}` isn't (or fails silently like now)?"_)

	The current behavior is actually preferred in some cases because some functions have an `options` parameter and it doesn't make sense to cache it by reference. Maybe this should be an explicit option: `{storeByReference: false}` is the current behavior while `true` would support all objects via `ManyKeysMap`

1. Currently `mem` lets you provide custom `cache` and `cacheKey`, possibly to work around existing issues with `JSON.stringify`. `many-keys-map` however is not a plain `Map` and the key **must** be an array (e.g. `arguments` itself), so it doesn’t lend itself well to customization via a separate parameter. Same for the `cache` `Map` itself.

	This could be solved by letting the user manage the whole cache. If they want to provide a map, we can’t be trusted with treating it the same way. The solution is to pass a single `cache` **getter**/**setter** that takes care of storing in its own `Map`. This would also free us from any `maxAge` and `clear` concerns.

	_Let `mem` manage the cache or do it yourself_

The advantage over #22 is that all types can be automatically supported.