### PR TITLE
Cache function reference when it's a single argument

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ declare namespace mem {
 		readonly maxAge?: number;
 
 		/**
-		Determines the cache key for storing the result based on the function arguments. By default, if there's only one argument and it's a [primitive](https://developer.mozilla.org/en-US/docs/Glossary/Primitive), it's used directly as a key, otherwise it's all the function arguments JSON stringified as an array.
+		Determines the cache key for storing the result based on the function arguments. By default, if there's only one argument and it's a [primitive](https://developer.mozilla.org/en-US/docs/Glossary/Primitive), it's used directly as a key (if it's a `function`, its reference will be used as key), otherwise it's all the function arguments JSON stringified as an array.
 
 		You could for example change it to only cache on the first argument `x => JSON.stringify(x)`.
 		*/

--- a/index.js
+++ b/index.js
@@ -12,7 +12,9 @@ const defaultCacheKey = (...arguments_) => {
 
 	if (arguments_.length === 1) {
 		const [firstArgument] = arguments_;
-		if (typeof firstArgument !== 'object' || firstArgument === null) {
+		const isObject = typeof firstArgument === 'object' && firstArgument !== null;
+		const isPrimitive = !isObject;
+		if (isPrimitive) {
 			return firstArgument;
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const defaultCacheKey = (...arguments_) => {
 		if (
 			firstArgument === null ||
 			firstArgument === undefined ||
-			typeof firstArgument === 'function'
+			typeof firstArgument !== 'object'
 		) {
 			return firstArgument;
 		}

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const defaultCacheKey = (...arguments_) => {
 		if (
 			firstArgument === null ||
 			firstArgument === undefined ||
-			(typeof firstArgument !== 'function' && typeof firstArgument !== 'object')
+			typeof firstArgument === 'function'
 		) {
 			return firstArgument;
 		}

--- a/index.js
+++ b/index.js
@@ -12,11 +12,7 @@ const defaultCacheKey = (...arguments_) => {
 
 	if (arguments_.length === 1) {
 		const [firstArgument] = arguments_;
-		if (
-			firstArgument === null ||
-			firstArgument === undefined ||
-			typeof firstArgument !== 'object'
-		) {
+		if (firstArgument === null || typeof firstArgument !== 'object') {
 			return firstArgument;
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const defaultCacheKey = (...arguments_) => {
 
 	if (arguments_.length === 1) {
 		const [firstArgument] = arguments_;
-		if (firstArgument === null || typeof firstArgument !== 'object') {
+		if (typeof firstArgument !== 'object' || firstArgument === null) {
 			return firstArgument;
 		}
 	}

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > [Memoize](https://en.wikipedia.org/wiki/Memoization) functions - An optimization used to speed up consecutive function calls by caching the result of calls with identical input
 
-The input is cached by value (if supported by `JSON.stringify`) unless it’s a single argument of type `function`, in which case it’s stored by reference. Memory is automatically released when an item expires.
+Memory is automatically released when an item expires.
 
 
 ## Install
@@ -101,7 +101,7 @@ Milliseconds until the cache expires.
 
 Type: `Function`
 
-Determines the cache key for storing the result based on the function arguments. By default, if there's only one argument and it's a [primitive](https://developer.mozilla.org/en-US/docs/Glossary/Primitive), it's used directly as a key, otherwise it's all the function arguments JSON stringified as an array.
+Determines the cache key for storing the result based on the function arguments. By default, if there's only one argument and it's a [primitive](https://developer.mozilla.org/en-US/docs/Glossary/Primitive), it's used directly as a key (if it's a `function`, its reference will be used as key), otherwise it's all the function arguments JSON stringified as an array.
 
 You could for example change it to only cache on the first argument `x => JSON.stringify(x)`.
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > [Memoize](https://en.wikipedia.org/wiki/Memoization) functions - An optimization used to speed up consecutive function calls by caching the result of calls with identical input
 
-The input is cached by reference when it’s not an object and when the argument is only one; it’s cached by value in all other cases (where `JSON.stringify` supports it). In the first case, memory is automatically released when an item expires (thanks to `WeakMap`).
+The input is cached by value (where `JSON.stringify` supports it) unless it’s a single argument and a function, in which case it’s stored by reference. Memory is automatically released when an item expires.
 
 
 ## Install

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > [Memoize](https://en.wikipedia.org/wiki/Memoization) functions - An optimization used to speed up consecutive function calls by caching the result of calls with identical input
 
-The input is cached by value (where `JSON.stringify` supports it) unless it’s a single argument and a function, in which case it’s stored by reference. Memory is automatically released when an item expires.
+The input is cached by value (if supported by `JSON.stringify`) unless it’s a single argument of type `function`, in which case it’s stored by reference. Memory is automatically released when an item expires.
 
 
 ## Install

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > [Memoize](https://en.wikipedia.org/wiki/Memoization) functions - An optimization used to speed up consecutive function calls by caching the result of calls with identical input
 
-Memory is automatically released when an item expires.
+The input is cached by reference when it’s not an object and when the argument is only one; it’s cached by value in all other cases (where `JSON.stringify` supports it). In the first case, memory is automatically released when an item expires (thanks to `WeakMap`).
 
 
 ## Install

--- a/test.js
+++ b/test.js
@@ -23,11 +23,11 @@ test('memoize', t => {
 	t.is(memoized(undefined), 5);
 	t.is(memoized(fixture), 6);
 	t.is(memoized(fixture), 6);
-	t.is(memoized(true), 6);
-	t.is(memoized(true), 6);
+	t.is(memoized(true), 7);
+	t.is(memoized(true), 7);
 
-	t.is(memoized(() => i++), 7);
 	t.is(memoized(() => i++), 8);
+	t.is(memoized(() => i++), 9);
 });
 
 test('memoize with multiple non-primitive arguments', t => {

--- a/test.js
+++ b/test.js
@@ -15,6 +15,19 @@ test('memoize', t => {
 	t.is(memoized('foo', 'bar'), 2);
 	t.is(memoized('foo', 'bar'), 2);
 	t.is(memoized('foo', 'bar'), 2);
+	t.is(memoized(1), 3);
+	t.is(memoized(1), 3);
+	t.is(memoized(null), 4);
+	t.is(memoized(null), 4);
+	t.is(memoized(undefined), 5);
+	t.is(memoized(undefined), 5);
+	t.is(memoized(fixture), 6);
+	t.is(memoized(fixture), 6);
+	t.is(memoized(true), 6);
+	t.is(memoized(true), 6);
+
+	t.is(memoized(() => i++), 7);
+	t.is(memoized(() => i++), 8);
 });
 
 test('memoize with multiple non-primitive arguments', t => {

--- a/test.js
+++ b/test.js
@@ -26,6 +26,7 @@ test('memoize', t => {
 	t.is(memoized(true), 7);
 	t.is(memoized(true), 7);
 
+	// Ensure that functions are stored by reference and not by "value" (e.g. their `.toString()` representation)
 	t.is(memoized(() => i++), 8);
 	t.is(memoized(() => i++), 9);
 });


### PR DESCRIPTION
Since the very first version, mem has a _"cache if it's not a function AND not an object"_, which I don't understand because functions are can't be serialized via `JSON.stringify`

In short (unless I'm drunk 🤔) I think `mem` should _always_ use the ONE argument as key, unless it's a serializable object.