### PR TITLE
Change the default value of the `cachePromiseRejection` option to `true`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ declare namespace mem {
 		/**
 		Cache rejected promises.
 
-		@default false
+		@default true
 		*/
 		readonly cachePromiseRejection?: boolean;
 	}

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const mem = (fn, options) => {
 	options = Object.assign({
 		cacheKey: defaultCacheKey,
 		cache: new Map(),
-		cachePromiseRejection: false
+		cachePromiseRejection: true
 	}, options);
 
 	if (typeof options.maxAge === 'number') {

--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,7 @@ Use a different cache storage. Must implement the following methods: `.has(key)`
 ##### cachePromiseRejection
 
 Type: `boolean`<br>
-Default: `false`
+Default: `true`
 
 Cache rejected promises.
 

--- a/test.js
+++ b/test.js
@@ -148,7 +148,7 @@ test('promise support', async t => {
 	t.is(await memoized(10), 1);
 });
 
-test('do not cache rejected promises', async t => {
+test('cachePromiseRejection option', async t => {
 	let i = 0;
 	const memoized = mem(async () => {
 		i++;
@@ -158,6 +158,8 @@ test('do not cache rejected promises', async t => {
 		}
 
 		return i;
+	}, {
+		cachePromiseRejection: false
 	});
 
 	await t.throwsAsync(memoized(), 'foo bar');


### PR DESCRIPTION
As a feature, this already feels weird because caching depends on this specific mechanism and not others like:

- should the function be cached if it returns `false`?
- should the function be cached if its call parameters include `{cache: false}`?

Having it avoid cache just because a promise is rejected feels arbitrary... but in a way I see that it's a flexible mechanism that allows any function (sync or async) to decide whether to avoid the cache.

That said, I don't think it should be a default, because:
- there's a chance that if something errors the first time, it will also error the second time (idempotency is a virtue);
- seen as a mechanism to avoid cache, it should be opt-in if needed, rather than an opaque behavior the developer didn't ask for.