### PR TITLE
Cleanup

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,6 @@ const mem = (fn, options = {}) => {
 		} : cacheItem);
 
 		if (isPromise(cacheItem) && cachePromiseRejection === false) {
-			// Remove rejected promises from cache if `cachePromiseRejection` is set to `false`
 			cacheItem.catch(() => cache.delete(key));
 		}
 

--- a/index.js
+++ b/index.js
@@ -22,14 +22,12 @@ const defaultCacheKey = (...arguments_) => {
 	return JSON.stringify(arguments_);
 };
 
-const mem = (fn, options = {}) => {
-	const {
-		cacheKey = defaultCacheKey,
-		cache = new Map(),
-		cachePromiseRejection = true,
-		maxAge
-	} = options;
-
+const mem = (fn, {
+	cacheKey = defaultCacheKey,
+	cache = new Map(),
+	cachePromiseRejection = true,
+	maxAge
+} = {}) => {
 	if (typeof maxAge === 'number') {
 		mapAgeCleaner(cache);
 	}

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ const mem = (fn, options = {}) => {
 			return maxAge ? cache.get(key).data : cache.get(key);
 		}
 
-		const cacheItem = fn.call(this, ...arguments_);
+		const cacheItem = fn.apply(this, arguments_);
 
 		cache.set(key, maxAge ? {
 			data: cacheItem,


### PR DESCRIPTION
- avoid repeating `options.`
- inline `setData` function
- avoid `mapAgeCleaner` wrapper, closes #27 