### PR TITLE
Simplify default serializer; drop promise-related option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,16 +20,34 @@ declare namespace mem {
 		readonly maxAge?: number;
 
 		/**
-		Determines the cache key for storing the result based on the function arguments. By default, if there's only one argument and it's a [primitive](https://developer.mozilla.org/en-US/docs/Glossary/Primitive), it's used directly as a key (if it's a `function`, its reference will be used as key), otherwise it's all the function arguments JSON stringified as an array.
+		Determines the cache key for storing the result based on the function arguments. By default, **only the first argument is considered** and it only works with [primitives](https://developer.mozilla.org/en-US/docs/Glossary/Primitive).
 
-		You could for example change it to only cache on the first argument `x => JSON.stringify(x)`.
+		A `cacheKey` function can return any type supported by `Map` (or whatever structure you use in the `cache` option).
+
+		You can have it cache **all** the arguments by value with `JSON.stringify`, if they are compatible:
+
+		```js
+		mem(function_, {cacheKey: JSON.stringify});
+		```
+
+		Or you can use a more full-featured serializer like [serialize-javascript](https://github.com/yahoo/serialize-javascript) to add support for `RegExp`, `Date` and so on.
+
+		```js
+		const serializeJavascript = require('serialize-javascript');
+
+		mem(function_, {cacheKey: serializeJavascript});
+		```
+
+		@default arguments_ => arguments_[0]
+		@example arguments_ => JSON.stringify(arguments_)
 		*/
 		readonly cacheKey?: (arguments: ArgumentsType) => CacheKeyType;
 
 		/**
-		Use a different cache storage. You could for example use a `WeakMap` instead or [`quick-lru`](https://github.com/sindresorhus/quick-lru) for a LRU cache.
+		Use a different cache storage. Must implement the following methods: `.has(key)`, `.get(key)`, `.set(key, value)`, `.delete(key)`, and optionally `.clear()`. You could for example use a `WeakMap` instead or [`quick-lru`](https://github.com/sindresorhus/quick-lru) for a LRU cache.
 
 		@default new Map()
+		@example new WeakMap()
 		*/
 		readonly cache?: CacheStorage<CacheKeyType, {data: ReturnType; maxAge: number}>;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare namespace mem {
 
 		You could for example change it to only cache on the first argument `x => JSON.stringify(x)`.
 		*/
-		readonly cacheKey?: (...arguments: ArgumentsType) => CacheKeyType;
+		readonly cacheKey?: (arguments: ArgumentsType) => CacheKeyType;
 
 		/**
 		Use a different cache storage. You could for example use a `WeakMap` instead or [`quick-lru`](https://github.com/sindresorhus/quick-lru) for a LRU cache.
@@ -32,13 +32,6 @@ declare namespace mem {
 		@default new Map()
 		*/
 		readonly cache?: CacheStorage<CacheKeyType, {data: ReturnType; maxAge: number}>;
-
-		/**
-		Cache rejected promises.
-
-		@default true
-		*/
-		readonly cachePromiseRejection?: boolean;
 	}
 }
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -9,12 +9,11 @@ expectType<(string: string) => boolean>(mem(fn, {cacheKey: (...arguments_) => ar
 expectType<(string: string) => boolean>(
 	mem(
 		fn,
-		{cacheKey: (...arguments_) => arguments_,
+		{cacheKey: (arguments_) => arguments_,
 		cache: new Map<[string], {data: boolean; maxAge: number}>()})
 );
 expectType<(string: string) => boolean>(
 	mem(fn, {cache: new Map<[string], {data: boolean; maxAge: number}>()})
 );
-expectType<(string: string) => boolean>(mem(fn, {cachePromiseRejection: false}));
 
 mem.clear(fn);

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
 	],
 	"dependencies": {
 		"map-age-cleaner": "^0.1.3",
-		"mimic-fn": "^2.1.0",
-		"p-is-promise": "^2.1.0"
+		"mimic-fn": "^2.1.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",
 		"delay": "^4.1.0",
+		"serialize-javascript": "^1.7.0",
 		"tsd": "^0.7.3",
 		"xo": "^0.24.0"
 	}

--- a/readme.md
+++ b/readme.md
@@ -24,15 +24,19 @@ const memoized = mem(counter);
 memoized('foo');
 //=> 1
 
-// Cached as it's the same arguments
+// Cached as it's the same argument
 memoized('foo');
 //=> 1
 
-// Not cached anymore as the arguments changed
+// Not cached anymore as the argument changed
 memoized('bar');
 //=> 2
 
 memoized('bar');
+//=> 2
+
+// Only the first argument is considered by default
+memoized('bar', 'foo');
 //=> 2
 ```
 
@@ -101,9 +105,20 @@ Milliseconds until the cache expires.
 
 Type: `Function`
 
-Determines the cache key for storing the result based on the function arguments. By default, if there's only one argument and it's a [primitive](https://developer.mozilla.org/en-US/docs/Glossary/Primitive), it's used directly as a key (if it's a `function`, its reference will be used as key), otherwise it's all the function arguments JSON stringified as an array.
+Determines the cache key for storing the result based on the function arguments. By default, only the first argument is used, as is, as the `key` of the `cache` `Map`.
 
-You could for example change it to only cache on the first argument `x => JSON.stringify(x)`.
+You change it to cache **all** the arguments by value with `JSON.stringify`, if they are compatible:
+
+```js
+mem(function_, {cacheKey: JSON.stringify})
+```
+
+Or you can use a more full-featured serializer like [serialize-javascript](https://github.com/yahoo/serialize-javascript) to add support for `RegExp`, `Date` and so on.
+
+```js
+const serializeJavascript = require('serialize-javascript');
+mem(function_, {cacheKey: serializeJavascript})
+```
 
 ##### cache
 
@@ -111,13 +126,6 @@ Type: `object`<br>
 Default: `new Map()`
 
 Use a different cache storage. Must implement the following methods: `.has(key)`, `.get(key)`, `.set(key, value)`, `.delete(key)`, and optionally `.clear()`. You could for example use a `WeakMap` instead or [`quick-lru`](https://github.com/sindresorhus/quick-lru) for a LRU cache.
-
-##### cachePromiseRejection
-
-Type: `boolean`<br>
-Default: `true`
-
-Cache rejected promises.
 
 ### mem.clear(fn)
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,9 @@
 
 > [Memoize](https://en.wikipedia.org/wiki/Memoization) functions - An optimization used to speed up consecutive function calls by caching the result of calls with identical input
 
-Memory is automatically released when an item expires.
+Memory is automatically released when an item expires or the cache is cleared.
+
+By default, **only the first argument is considered** and it only works with [primitives](https://developer.mozilla.org/en-US/docs/Glossary/Primitive). If you need to cache multiple arguments or cache `object`s _by value_, use the `cacheKey` option.
 
 
 ## Install
@@ -104,8 +106,8 @@ Milliseconds until the cache expires.
 ##### cacheKey
 
 Type: `Function`
-Default: `_arguments => _arguments[0]`
-Example: `_arguments => JSON.stringify(_arguments)`
+Default: `arguments_ => arguments_[0]`
+Example: `arguments_ => JSON.stringify(arguments_)`
 
 Determines the cache key for storing the result based on the function arguments. By default, **only the first argument is considered**.
 
@@ -114,14 +116,15 @@ A `cacheKey` function can return any type supported by `Map` (or whatever struct
 You can have it cache **all** the arguments by value with `JSON.stringify`, if they are compatible:
 
 ```js
-mem(function_, {cacheKey: JSON.stringify})
+mem(function_, {cacheKey: JSON.stringify});
 ```
 
 Or you can use a more full-featured serializer like [serialize-javascript](https://github.com/yahoo/serialize-javascript) to add support for `RegExp`, `Date` and so on.
 
 ```js
 const serializeJavascript = require('serialize-javascript');
-mem(function_, {cacheKey: serializeJavascript})
+
+mem(function_, {cacheKey: serializeJavascript});
 ```
 
 ##### cache

--- a/readme.md
+++ b/readme.md
@@ -104,10 +104,14 @@ Milliseconds until the cache expires.
 ##### cacheKey
 
 Type: `Function`
+Default: `_arguments => _arguments[0]`
+Example: `_arguments => JSON.stringify(_arguments)`
 
-Determines the cache key for storing the result based on the function arguments. By default, only the first argument is used, as is, as the `key` of the `cache` `Map`.
+Determines the cache key for storing the result based on the function arguments. By default, **only the first argument is considered**.
 
-You change it to cache **all** the arguments by value with `JSON.stringify`, if they are compatible:
+A `cacheKey` function can return any type supported by `Map` (or whatever structure you use in the `cache` option).
+
+You can have it cache **all** the arguments by value with `JSON.stringify`, if they are compatible:
 
 ```js
 mem(function_, {cacheKey: JSON.stringify})


### PR DESCRIPTION
Implements and closes #40 
Replaces and closes #22
Fixes #20
(Basically merging this PR will close everything in this repo 🎉)

In short, what used to be known as `cacheKey: x => x` is now the default.

This default aligns `mem` with other common memoize implementations (like lodash) while still supporting and suggesting a variety of serialization methods which the user can pick.

This makes the memoization logic very straightforward, explicit and fast by default. Refer to [the new readme](https://github.com/sindresorhus/mem/tree/ede5403a634cbe40fc8e36b71644ceebf439501e#cachekey)

---

The main API change is the new signature of `cacheKey`, which instead of receiving the arguments as `cacheKey(...arguments_)`, it receives them as an array. This change makes it easy to supply a plain serializer like:

```js
mem(() => i++, {cacheKey: JSON.stringify});
mem(() => i++, {cacheKey: serializeJavascript});
```

Instead of having to wrap & lengthen the two most likely implementations:

```js
mem(() => i++, {cacheKey: (...args) => JSON.stringify(args)}); // 😬
mem(() => i++, {cacheKey: (...args) => serializeJavascript(args)}); // 😖
```

---

Since this will be a breaking change, I dropped `cachePromiseRejection` since it makes more sense as part of `p-memoize`. This change also makes it easy to copy `mem` into `p-memoize` [as suggested by Sindre](https://github.com/sindresorhus/p-memoize/issues/3#issuecomment-405025314) instead of having to maintain an increasingly-complex in-house stringifier [like what's in #22](https://github.com/sindresorhus/mem/blob/4d72500730c9cb40f8b40e38e1f4c8bbdafba18e/index.js#L6-L43)