### PR TITLE
Throw when `.clear()` is called with a non-memoized function

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,9 +77,12 @@ const mem = (fn, options) => {
 module.exports = mem;
 
 module.exports.clear = fn => {
-	const cache = cacheStore.get(fn);
+	if (!cacheStore.has(fn)) {
+		throw new Error('Can\'t clear a function that was not memoized!');
+	}
 
-	if (cache && typeof cache.clear === 'function') {
+	const cache = cacheStore.get(fn);
+	if (typeof cache.clear === 'function') {
 		cache.clear();
 	}
 };

--- a/test.js
+++ b/test.js
@@ -238,3 +238,9 @@ test('prototype support', t => {
 	t.is(unicorn.foo(), 0);
 	t.is(unicorn.foo(), 0);
 });
+
+test('mem.clear() throws when called with a plain function', t => {
+	t.throws(() => {
+		mem.clear(() => {});
+	}, 'Can\'t clear a function that was not memoized!');
+});


### PR DESCRIPTION
This aligns the behavior with `p-memoize`, if it's desirable.

Breaking change