### PR TITLE
Expose a `has` method to check the `cacheStore`

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,10 @@ const mem = (fn, {
 
 module.exports = mem;
 
+module.exports.has = fn => {
+	return cacheStore.has(fn);
+}
+
 module.exports.clear = fn => {
 	if (!cacheStore.has(fn)) {
 		throw new Error('Can\'t clear a function that was not memoized!');


### PR DESCRIPTION
With the recent `v6.0.0` update, calling `clear` on a non-memoized function will throw.

## Problem
There's no way to check the `cacheStore` since it's not an exported variable.

## Solution
Expose a `has` method to check the `cacheStore` if function is memoized.