### PR TITLE
Automatically use WeakMap when possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,17 +4,14 @@ const mapAgeCleaner = require('map-age-cleaner');
 
 const cacheStore = new WeakMap();
 
-const mem = (fn, {
-	cacheKey = ([firstArgument]) => firstArgument,
-	cache,
-	maxAge
-} = {}) => {
+const mem = (fn, options = {}) => {
 	// Automatically use WeakMap unless the user provided their own cache
-	let weakCache;
-	if (!cache) {
-		weakCache = new WeakMap();
-		cache = new Map();
-	}
+	const weakCache = options.cache || new WeakMap();
+	const {
+		cacheKey = ([firstArgument]) => firstArgument,
+		cache = new Map(),
+		maxAge
+	} = options;
 
 	if (typeof maxAge === 'number') {
 		mapAgeCleaner(cache);

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const mem = (fn, options = {}) => {
 		const key = cacheKey(arguments_);
 
 		// Prefer WeakMap if the key allows it
-		const bestCache = weakCache && key && (typeof key === 'object' || typeof key === 'function') ?
+		const bestCache = key && (typeof key === 'object' || typeof key === 'function') ?
 			weakCache :
 			cache;
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const mem = (fn, {
 	// Automatically use WeakMap unless the user provided their own cache
 	let weakCache;
 	if (!cache) {
-		weakCache = new WeakCache();		
+		weakCache = new WeakMap();
 		cache = new Map();
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -193,9 +193,9 @@ Refer to the [caching strategies](#caching-strategy) section for more informatio
 ##### cache
 
 Type: `object`\
-Default: `new Map()`
+Default: `new Map()`, but it also intelligently uses `new WeakMap()` whenevever possible
 
-Use a different cache storage. Must implement the following methods: `.has(key)`, `.get(key)`, `.set(key, value)`, `.delete(key)`, and optionally `.clear()`. You could for example use a `WeakMap` instead or [`quick-lru`](https://github.com/sindresorhus/quick-lru) for a LRU cache.
+Use a different cache storage. Must implement the following methods: `.has(key)`, `.get(key)`, `.set(key, value)`, `.delete(key)`, and optionally `.clear()`. You could for example use [`quick-lru`](https://github.com/sindresorhus/quick-lru) for a LRU cache.
 
 Refer to the [caching strategies](#caching-strategy) section for more information.
 


### PR DESCRIPTION
`mem` doesn't **_need_** `Map`, it's just that `WeakMap` doesn't support most primitives. If it could, it should _only_ use `WeakMap`


Proposal: use `WeakMap`...

- if `cache` isn't provided by the user
- when the current `key` is supported by `WeakMap`

This is automatic and silent.