### PR TITLE
Throw on clear(fn) if fn’s cache can't be cleared

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -141,12 +141,14 @@ Clear all cached data of a memoized function.
 @param fn - Memoized function.
 */
 mem.clear = (fn: (...arguments_: any[]) => any): void => {
-	if (!cacheStore.has(fn)) {
-		throw new Error('Can\'t clear a function that was not memoized!');
+	const cache = cacheStore.get(fn);
+	if (!cache) {
+		throw new TypeError('Can\'t clear a function that was not memoized!');
 	}
 
-	const cache = cacheStore.get(fn);
-	if (typeof cache.clear === 'function') {
-		cache.clear();
+	if (typeof cache.clear !== 'function') {
+		throw new TypeError('The cache Map can\'t be cleared!');
 	}
+
+	cache.clear();
 };

--- a/test.js
+++ b/test.js
@@ -198,6 +198,21 @@ test('mem.clear() throws when called with a plain function', t => {
 	t.throws(() => {
 		mem.clear(() => {});
 	}, {
-		message: 'Can\'t clear a function that was not memoized!'
+		message: 'Can\'t clear a function that was not memoized!',
+		instanceOf: TypeError
+	});
+});
+
+test('mem.clear() throws when called on an unclearable cache', t => {
+	const fixture = () => 1;
+	const memoized = mem(fixture, {
+		cache: new WeakMap()
+	});
+
+	t.throws(() => {
+		mem.clear(memoized);
+	}, {
+		message: 'The cache Map can\'t be cleared!',
+		instanceOf: TypeError
 	});
 });


### PR DESCRIPTION
Breaking change, to be released after #58 (which is a patch for the current version)

What's the point of calling `clear(fn)` if it does nothing? This just causes silent errors.

Regarding throwing errors:

- I can **drop** the explicit `Can't clear a function that was not memoized!` error since now it throws anyway, OR
- I can **add** an `unclearable cache` error
