### PR TITLE
Infer `cacheKey` arguments type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ declare namespace mem {
 	}
 
 	interface Options<
-		ArgumentsType extends any[],
+		ArgumentsType extends unknown[],
 		CacheKeyType,
 		ReturnType
 	> {
@@ -86,13 +86,13 @@ declare const mem: {
 	```
 	*/
 	<
-		ArgumentsType extends any[],
+		ArgumentsType extends unknown[],
 		ReturnType,
 		CacheKeyType,
-		FunctionToMemoize extends (...arguments: ArgumentsType) => ReturnType
+		FunctionToMemoize = (...arguments: ArgumentsType) => ReturnType
 	>(
 		fn: FunctionToMemoize,
-		options?: mem.Options<Parameters<typeof fn>, CacheKeyType, ReturnType>
+		options?: mem.Options<FunctionToMemoize extends (...arguments: infer P) => ReturnType ? P : never, CacheKeyType, ReturnType>
 	): FunctionToMemoize;
 
 	/**
@@ -100,7 +100,7 @@ declare const mem: {
 
 	@param fn - Memoized function.
 	*/
-	clear<ArgumentsType extends any[], ReturnType>(
+	clear<ArgumentsType extends unknown[], ReturnType>(
 		fn: (...arguments: ArgumentsType) => ReturnType
 	): void;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ declare namespace mem {
 	}
 
 	interface Options<
-		ArgumentsType extends unknown[],
+		ArgumentsType extends any[],
 		CacheKeyType,
 		ReturnType
 	> {
@@ -86,13 +86,13 @@ declare const mem: {
 	```
 	*/
 	<
-		ArgumentsType extends unknown[],
+		ArgumentsType extends any[],
 		ReturnType,
 		CacheKeyType,
-		FunctionToMemoize = (...arguments: ArgumentsType) => ReturnType
+		FunctionToMemoize extends (...arguments: ArgumentsType) => ReturnType
 	>(
 		fn: FunctionToMemoize,
-		options?: mem.Options<FunctionToMemoize extends (...arguments: infer P) => ReturnType ? P : never, CacheKeyType, ReturnType>
+		options?: mem.Options<Parameters<FunctionToMemoize>, CacheKeyType, ReturnType>
 	): FunctionToMemoize;
 
 	/**
@@ -100,7 +100,7 @@ declare const mem: {
 
 	@param fn - Memoized function.
 	*/
-	clear<ArgumentsType extends unknown[], ReturnType>(
+	clear<ArgumentsType extends any[], ReturnType>(
 		fn: (...arguments: ArgumentsType) => ReturnType
 	): void;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ declare namespace mem {
 	}
 
 	interface Options<
-		ArgumentsType extends unknown[],
+		ArgumentsType extends any[],
 		CacheKeyType,
 		ReturnType
 	> {
@@ -100,7 +100,7 @@ declare const mem: {
 
 	@param fn - Memoized function.
 	*/
-	clear<ArgumentsType extends unknown[], ReturnType>(
+	clear<ArgumentsType extends any[], ReturnType>(
 		fn: (...arguments: ArgumentsType) => ReturnType
 	): void;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -89,10 +89,10 @@ declare const mem: {
 		ArgumentsType extends unknown[],
 		ReturnType,
 		CacheKeyType,
-		FunctionToMemoize = (...arguments: ArgumentsType) => ReturnType
+		FunctionToMemoize extends (...arguments: ArgumentsType) => ReturnType
 	>(
 		fn: FunctionToMemoize,
-		options?: mem.Options<ArgumentsType, CacheKeyType, ReturnType>
+		options?: mem.Options<Parameters<typeof fn>, CacheKeyType, ReturnType>
 	): FunctionToMemoize;
 
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -86,7 +86,7 @@ declare const mem: {
 	```
 	*/
 	<
-		ArgumentsType extends unknown[],
+		ArgumentsType extends any[],
 		ReturnType,
 		CacheKeyType,
 		FunctionToMemoize extends (...arguments: ArgumentsType) => ReturnType

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -16,6 +16,13 @@ expectType<typeof fn>(
 	mem(fn, {cache: new Map<[string], {data: boolean; maxAge: number}>()})
 );
 
+
+mem(fn, {
+	cacheKey: (arguments_) => {
+		expectType<[string]>(arguments_)
+	}
+});
+
 /* Overloaded function tests */
 function overloadedFn(parameter: false): false;
 function overloadedFn(parameter: true): true;


### PR DESCRIPTION
issue link: https://github.com/sindresorhus/mem/issues/50

solution: use`Parameters<typeof fn>` to infer type of cacheKey arguments