### PR TITLE
Fixes a bug in cacheKey, simplifies, adds more robust testing to TS signatures

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -9,12 +9,46 @@ expectType<typeof fn>(mem(fn, {cacheKey: (...arguments_) => arguments_}));
 expectType<typeof fn>(
 	mem(
 		fn,
-		{cacheKey: (arguments_) => arguments_,
-		cache: new Map<[string], {data: boolean; maxAge: number}>()})
+		{
+			cacheKey: (arguments_) => "strValue",
+			cache: new Map<string, {data: boolean; maxAge: number}>()
+		}
+	)
 );
 expectType<typeof fn>(
-	mem(fn, {cache: new Map<[string], {data: boolean; maxAge: number}>()})
+	mem(fn, {cache: new Map<string, {data: boolean; maxAge: number}>()})
 );
+
+// Testing that the full cache object works with type inference
+const objFnReturnsNum = function({ key }: { key: string }) { return 10 }
+expectType<typeof objFnReturnsNum>(
+	mem(
+		objFnReturnsNum,
+		{
+			cacheKey : function(args: [{ key: string }]) {
+				return new Date();
+			},
+			cache : {
+				get: function(key: Date) {
+					return {
+						data: 5,
+						maxAge : 2
+					}
+				},
+				set : function(key: Date, value: { data : number, maxAge : number }) {
+
+				},
+				has : function(key: Date) {
+					return true;
+				},
+				delete : function(key: Date) {
+
+				},
+				clear : function() {}
+			}
+		}
+	)
+)
 
 /* Overloaded function tests */
 function overloadedFn(parameter: false): false;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -10,7 +10,7 @@ expectType<typeof fn>(
 	mem(
 		fn,
 		{
-			cacheKey: (arguments_) => "strValue",
+			cacheKey: (arguments_) => arguments_[0],
 			cache: new Map<string, {data: boolean; maxAge: number}>()
 		}
 	)


### PR DESCRIPTION
This corrects and adds more robust testing for a variety of flaws in the TS signatures for mem.

* The `cacheKey` function was receiving the improper signature. As the code is written the argument in the first position will be the totality of the arguments array so `cacheKey : function(args) {}` where `args = [arg0, arg1, arg2]`.  The previous code was using the magic `arguments` which resulted in `cacheKey : function(arg0, arg1) {}` which was incorrect.
* Using `Parameters` and `ReturnType` we can make use of some of the builtins that TS provides to simplify. 
* There wasn't a robust testing for the interaction between the `cacheKey` and `cache` in the way that the return type of `cacheKey` affects the incoming parameters received by `cache`. Added a complex test for that example.
* The `clear` method had a much more complicated than necessary signature. Effectively all that matter is that it takes a function, right?
* Pre-existing tests were erroneously declaring the Map as `Map<[string], ...>` that would indicate that the key in the Map is an array of strings, but that isn't the case for the default state of `mem`. If no cacheKey is specified the default is the first argument, and in that test the first argument is a string, so the default map state should be string.

Hit me up for any feedback or issues. Thanks.