### PR TITLE
Avoid `mimicFn` error without try/catch

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -129,11 +129,9 @@ const mem = <
 		return result;
 	} as FunctionToMemoize;
 
-	try {
-		// The below call will throw in some host environments
-		// See https://github.com/sindresorhus/mimic-fn/issues/10
-		mimicFn(memoized, fn);
-	} catch {}
+	mimicFn(memoized, fn, {
+		ignoreNonConfigurable: true
+	});
 
 	cacheStore.set(memoized, cache);
 


### PR DESCRIPTION
https://github.com/sindresorhus/mimic-fn/pull/34 avoids this error, is that correct?