### PR TITLE
Don't use the same memoized function across instances when `.decorator()` is used

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -68,15 +68,6 @@ interface Options<
 	readonly cache?: CacheStorage<CacheKeyType, ReturnType<FunctionToMemoize>>;
 }
 
-interface DecoratorOptions {
-	/**
-	Whether the same memoized function should be used in different instances or a different one should be initialised for each one.
-
-	@default false
-	*/
-	readonly isAcrossInstances?: boolean;
-}
-
 /**
 [Memoize](https://en.wikipedia.org/wiki/Memoization) functions - An optimization used to speed up consecutive function calls by caching the result of calls with identical input.
 
@@ -152,7 +143,7 @@ const mem = <
 export = mem;
 
 /**
-@returns A TypeScript decorator which memoizes the given function.
+@returns A [decorator](https://github.com/tc39/proposal-decorators) to memoize class methods or static class functions.
 
 @example
 ```
@@ -181,10 +172,7 @@ mem.decorator = <
 	FunctionToMemoize extends AnyFunction,
 	CacheKeyType
 >(
-	{
-		isAcrossInstances = false,
-		...options
-	}: Options<FunctionToMemoize, CacheKeyType> & DecoratorOptions = {}
+	options: Options<FunctionToMemoize, CacheKeyType> = {}
 ) => (
 	target: any,
 	propertyKey: string,
@@ -194,11 +182,6 @@ mem.decorator = <
 
 	if (typeof input !== 'function') {
 		throw new TypeError('The decorated value must be a function');
-	}
-
-	if (isAcrossInstances) {
-		descriptor.value = mem(input, options);
-		return;
 	}
 
 	delete descriptor.value;

--- a/index.ts
+++ b/index.ts
@@ -143,7 +143,7 @@ const mem = <
 export = mem;
 
 /**
-@returns A [decorator](https://github.com/tc39/proposal-decorators) to memoize class methods or static class functions.
+@returns A [decorator](https://github.com/tc39/proposal-decorators) to memoize class methods or static class methods.
 
 @example
 ```

--- a/readme.md
+++ b/readme.md
@@ -204,7 +204,14 @@ Returns a TypeScript decorator which memoizes the given function.
 
 Type: `object`
 
-Same as options for `mem()`.
+Same as options for `mem()` and the following:
+
+##### isAcrossInstances
+
+Type: `boolean`\
+Default: `false`
+
+Whether the same memoized function should be used in different instances or a different one should be initialised for each one.
 
 ```ts
 import mem = require('mem');

--- a/readme.md
+++ b/readme.md
@@ -198,7 +198,7 @@ Refer to the [caching strategies](#caching-strategy) section for more informatio
 
 ### mem.decorator(options)
 
-Returns a [decorator](https://github.com/tc39/proposal-decorators) to memoize class methods.
+Returns a [decorator](https://github.com/tc39/proposal-decorators) to memoize class methods or static class functions.
 
 Notes:
 
@@ -210,14 +210,7 @@ Notes:
 
 Type: `object`
 
-Same as options for `mem()` and the following:
-
-##### isAcrossInstances
-
-Type: `boolean`\
-Default: `false`
-
-Whether the same memoized function should be used in different instances or a different one should be initialised for each one.
+Same as options for `mem()`.
 
 ```ts
 import mem = require('mem');

--- a/readme.md
+++ b/readme.md
@@ -198,7 +198,7 @@ Refer to the [caching strategies](#caching-strategy) section for more informatio
 
 ### mem.decorator(options)
 
-Returns a [decorator](https://github.com/tc39/proposal-decorators) to memoize class methods or static class functions.
+Returns a [decorator](https://github.com/tc39/proposal-decorators) to memoize class methods or static class methods.
 
 Notes:
 

--- a/test.ts
+++ b/test.ts
@@ -238,12 +238,12 @@ test('prototype support', t => {
 });
 
 test('.decorator()', t => {
-	class TestClass {
-		index = 0;
+	let returnValue = 1;
 
+	class TestClass {
 		@mem.decorator()
 		counter() {
-			return ++this.index;
+			return returnValue;
 		}
 	}
 
@@ -251,8 +251,28 @@ test('.decorator()', t => {
 	t.is(alpha.counter(), 1);
 	t.is(alpha.counter(), 1, 'The method should be memoized');
 
+	returnValue++;
+
 	const beta = new TestClass();
-	t.is(beta.counter(), 1, 'The method should not be memoized across instances');
+	t.is(beta.counter(), 2, 'The method should not be memoized across instances');
+
+	returnValue++;
+
+	class TestClass2 {
+		@mem.decorator({isAcrossInstances: true})
+		counter() {
+			return returnValue;
+		}
+	}
+
+	const charlie = new TestClass2();
+	t.is(charlie.counter(), 3);
+	t.is(charlie.counter(), 3, 'The method should be memoized');
+
+	returnValue++;
+
+	const delta = new TestClass2();
+	t.is(delta.counter(), 3, 'The method should be memoized across instances');
 });
 
 test('mem.clear() throws when called with a plain function', t => {

--- a/test.ts
+++ b/test.ts
@@ -255,24 +255,6 @@ test('.decorator()', t => {
 
 	const beta = new TestClass();
 	t.is(beta.counter(), 2, 'The method should not be memoized across instances');
-
-	returnValue++;
-
-	class TestClass2 {
-		@mem.decorator({isAcrossInstances: true})
-		counter() {
-			return returnValue;
-		}
-	}
-
-	const charlie = new TestClass2();
-	t.is(charlie.counter(), 3);
-	t.is(charlie.counter(), 3, 'The method should be memoized');
-
-	returnValue++;
-
-	const delta = new TestClass2();
-	t.is(delta.counter(), 3, 'The method should be memoized across instances');
 });
 
 test('mem.clear() throws when called with a plain function', t => {


### PR DESCRIPTION
Fixes: #74