### PR TITLE
Export `Options` type from package

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ interface CacheStorage<KeyType, ValueType> {
 	clear?: () => void;
 }
 
-interface Options<
+export interface Options<
 	FunctionToMemoize extends AnyFunction,
 	CacheKeyType,
 > {


### PR DESCRIPTION
Export the `Options` type so consumers can reference the type. This was exported in 6.1.1 and lost during the TypeScript refactor.

The only other way to reference the type is `Paramaters<typeof mem>[1]` which isn't very ergonomic, and doesn't expose the generic parameters.