### PR TITLE
Add `isMemoized()` and `Memoized` type

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,28 @@ const cacheStore = new WeakMap<AnyFunction, CacheLike<unknown, unknown>>();
 const cacheTimerStore = new WeakMap<AnyFunction, Set<Timer>>();
 const cacheKeyStore = new WeakMap<AnyFunction, (arguments_: readonly any[]) => unknown>();
 
+declare const memoizedBrand: unique symbol;
+
+/**
+A function that has been verified as memoized by `isMemoized()`.
+
+Use it to accept only memoized functions. Since `memoize()` mimics the given function entirely, the only way to get this type is through the `isMemoized()` guard.
+
+@example
+```
+import memoize, {isMemoized, type Memoized} from 'memoize';
+
+const use = (function_: Memoized<(text: string) => boolean>) => function_('foo');
+
+const memoized = memoize((text: string) => Boolean(text));
+
+if (isMemoized(memoized)) {
+	use(memoized);
+}
+```
+*/
+export type Memoized<FunctionToMemoize extends AnyFunction> = FunctionToMemoize & {readonly [memoizedBrand]: true};
+
 export type CacheItem<ValueType> = {
 	data: ValueType;
 	maxAge: number;
@@ -122,8 +144,7 @@ function getPropertyDescriptor(object: WeakKey, property: string | symbol): Prop
 			return descriptor;
 		}
 
-		const prototype: unknown = Object.getPrototypeOf(currentObject);
-		currentObject = prototype === null ? undefined : prototype as WeakKey;
+		currentObject = (Object.getPrototypeOf(currentObject) ?? undefined) as WeakKey | undefined;
 	}
 
 	return undefined;
@@ -430,4 +451,29 @@ export function memoizeIsCached<FunctionToMemoize extends AnyFunction>(
 	const key = cacheKey(arguments_);
 	const item = getValidCacheItem(cache, key);
 	return item !== undefined;
+}
+
+/**
+Check whether a function is memoized.
+
+@param function_ - The function to check.
+@returns `true` if the function was returned by `memoize()`, `false` otherwise.
+
+Note: `memoize()` returns the given function unchanged when the `maxAge` option is `0` or negative, as nothing is cached. Such a function is correctly reported as not memoized.
+
+@example
+```
+import memoize, {isMemoized} from 'memoize';
+
+const function_ = (text: string) => Boolean(text);
+
+isMemoized(memoize(function_));
+//=> true
+
+isMemoized(function_);
+//=> false
+```
+*/
+export function isMemoized<FunctionToMemoize extends AnyFunction>(function_: FunctionToMemoize): function_ is Memoized<FunctionToMemoize> {
+	return cacheStore.has(function_);
 }

--- a/readme.md
+++ b/readme.md
@@ -297,6 +297,47 @@ Type: `Function`
 
 The memoized function.
 
+### isMemoized(fn)
+
+Check whether a function is memoized.
+
+Returns `true` if the function was returned by `memoize()`, `false` otherwise.
+
+> [!NOTE]
+> `memoize()` returns the given function unchanged when the `maxAge` option is `0` or negative, as nothing is cached. Such a function is correctly reported as not memoized.
+
+```js
+import memoize, {isMemoized} from 'memoize';
+
+const function_ = (text) => Boolean(text);
+
+isMemoized(memoize(function_));
+//=> true
+
+isMemoized(function_);
+//=> false
+```
+
+In TypeScript, it narrows the function to the `Memoized` type, which lets you accept only memoized functions:
+
+```ts
+import memoize, {isMemoized, type Memoized} from 'memoize';
+
+const use = (function_: Memoized<(text: string) => boolean>) => function_('foo');
+
+const memoized = memoize((text: string) => Boolean(text));
+
+if (isMemoized(memoized)) {
+	use(memoized);
+}
+```
+
+#### fn
+
+Type: `Function`
+
+The function to check.
+
 #### arguments
 
 The arguments to check.

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -1,5 +1,11 @@
 import {expectType} from 'tsd';
-import memoize, {memoizeClear, memoizeDecorator, memoizeIsCached} from '../index.js';
+import memoize, {
+	memoizeClear,
+	memoizeDecorator,
+	memoizeIsCached,
+	isMemoized,
+	type Memoized,
+} from '../index.js';
 
 // eslint-disable-next-line unicorn/prefer-native-coercion-functions -- Required `string` type
 const function_ = (text: string) => Boolean(text);
@@ -97,3 +103,9 @@ const decorated = new DecoratedClass();
 expectType<string>(decorated.method('test'));
 expectType<string>(DecoratedClass.staticMethod('test'));
 expectType<string>(decorated.getter);
+
+// `isMemoized()` narrows to `Memoized`
+const maybeMemoized: (text: string) => boolean = memoize(function_);
+if (isMemoized(maybeMemoized)) {
+	expectType<Memoized<(text: string) => boolean>>(maybeMemoized);
+}

--- a/test.ts
+++ b/test.ts
@@ -1,7 +1,12 @@
 import test from 'ava';
 import delay from 'delay';
 import serializeJavascript from 'serialize-javascript';
-import memoize, {memoizeDecorator, memoizeClear, memoizeIsCached} from './index.js';
+import memoize, {
+	memoizeDecorator,
+	memoizeClear,
+	memoizeIsCached,
+	isMemoized,
+} from './index.js';
 
 test('memoize', t => {
 	let index = 0;
@@ -1121,4 +1126,29 @@ test('very short maxAge expiration', async t => {
 	// After expiration
 	await delay(15);
 	t.is(memoized('a'), 1);
+});
+
+test('isMemoized()', t => {
+	const fixture = (value?: unknown) => 42;
+
+	t.true(isMemoized(memoize(fixture)));
+	t.false(isMemoized(fixture));
+
+	// `memoize()` returns the function unchanged when nothing is cached
+	t.false(isMemoized(memoize(fixture, {maxAge: 0})));
+});
+
+test('isMemoized() with decorated methods', t => {
+	class TestClass {
+		index = 0;
+
+		@memoizeDecorator()
+		counter() {
+			return ++this.index;
+		}
+	}
+
+	const instance = new TestClass();
+	t.true(isMemoized(instance.counter));
+	t.false(isMemoized(TestClass.prototype.counter));
 });


### PR DESCRIPTION
The return type of `memoize()` is unchanged, so the tag is only earned after the runtime guard.

Fixes #114

---

Why not an `isMemoized` property on the returned function? It changes the shape of the function, which defeats the point of mimicking the input exactly. It's also trivially forgeable and would show up in spreads, `Object.keys`, and snapshots. The information already exists internally in a `WeakMap`, so the check needs no extra surface.

Why not brand the return type of `memoize()` by default? It would leak `Memoized<…>` into every hover and error message, and can cause declaration-emit friction for consumers re-exporting a memoized function. A brand on the return value is also just an assertion, whereas the guard reflects reality: `memoize(fn, {maxAge: 0})` returns the input unchanged since nothing is cached, and `isMemoized()` correctly reports `false` for it.